### PR TITLE
Added free text date fields

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/dateFieldsContent.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/dateFieldsContent.scala.html
@@ -1,0 +1,55 @@
+@*
+* Copyright 2015 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+@(formItem:Form[_], fieldName: String)(implicit lang: play.api.i18n.Lang)
+
+@import uk.gov.hmrc.play.mappers.DateFields._
+@import play.api.i18n._
+@import views.html.helper._
+@import uk.gov.hmrc.play.mappers.DateFormatSymbols
+
+@dayElem = @{ fieldName + "." + day }
+@dayInputId = @{ fieldName + "-" + day }
+
+@dateInputText(
+formItem(dayElem),
+'_inputId -> dayInputId,
+'_label -> Messages("date.fields.day"),
+'_labelClass -> "label--inline-tight",
+'_inputClass -> "input--xxsmall form-field--inline push--left",
+'_maxFieldLength -> 2, 'placeHolder ->"DD"
+)
+@monthElem = @{ fieldName + "." + month }
+@monthInputId = @{ fieldName + "-" + month }
+
+@dateInputText(
+formItem(monthElem),
+'_inputId -> monthInputId,
+'_label -> Messages("date.fields.month"),
+'_labelClass -> "label--inline-tight",
+'_inputClass -> "input--xxsmall form-field--inline push--left",
+'_maxFieldLength -> 2, 'placeHolder ->"MM"
+)
+@yearElem = @{ fieldName + "." + year }
+@yearInputId = @{ fieldName + "-" + year }
+
+@dateInputText(
+formItem(yearElem),
+'_inputId -> yearInputId,
+'_label -> Messages("date.fields.year"),
+'_labelClass -> "label--inline-tight",
+'_inputClass -> "input--xsmall form-field--inline push--left",
+'_maxFieldLength -> 4, 'placeHolder ->"YYYY"
+)

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/dateFieldsFreeText.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/dateFieldsFreeText.scala.html
@@ -1,0 +1,37 @@
+@*
+* Copyright 2015 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+@(formItem:Form[_], fieldName: String, label: Html, extraClass: Option[String], args: (Symbol,Any)*)(implicit lang: play.api.i18n.Lang)
+
+
+@import play.api.i18n._
+@import uk.gov.hmrc.play.mappers.DateFormatSymbols
+@import uk.gov.hmrc.play.mappers.DateFields._
+@import views.html.helper.FieldElements
+
+@elements = @{ new FieldElements(formItem(fieldName).id, formItem(fieldName), null, args.toMap, lang) }
+
+<fieldset class="@elements.args.get('_groupClass) touch @if(elements.hasErrors) {form-field--error}" id="@fieldName.replaceAll("[.]", "_")">
+<legend>@label</legend>
+@if(elements.args.get('_hintText).isDefined) {
+<p class="form-hint">@elements.args.get('_hintText)</p>
+}
+
+@elements.errors.map { error => <span class="error-notification">@Messages(error)</span>}
+
+<div class="no-touch native-date-picker form-date">
+    @dateFieldsContent(formItem, fieldName)
+</div>
+</fieldset>

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/dateInputText.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/dateInputText.scala.html
@@ -1,0 +1,44 @@
+@*
+* Copyright 2015 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit lang: play.api.i18n.Lang)
+
+@import play.api.i18n._
+@import views.html.helper._
+
+@elements = @{ new FieldElements(field.id, field, null, args.toMap, lang) }
+@parentField = @{args.toMap.get('parentField).asInstanceOf[Option[Field]]}
+
+@parentElements = @{parentField.map(pf => new FieldElements(pf.id, pf, null, Map(), lang) )}
+
+@value = @{ field.value match { case Some(x) => x case None => "" case x => x }}
+
+
+<div class="form-group">
+<label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if(elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) {form-field--error}" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
+@if(elements.args.contains('_label)) { @elements.label }
+</label>
+
+<input @if(elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
+@if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
+@if( elements.args.get('_maxFieldLength) ){ maxlength="@elements.args.get('_maxFieldLength)" }
+
+@if(elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
+@if(elements.args.contains('placeHolder) ){ placeHolder="@elements.args.get('placeHolder)"}
+name="@elements.field.name"
+id="@elements.args.get('_inputId)"
+value="@value"
+/>
+</div>


### PR DESCRIPTION
Hi @xnejp03, would you mind having a look at this PR, it includes free text inputs for date entries.
Copied from some hmrc other projects, so it'd be good to have it in one central place, not sure whether all stylings are needed though.
@benaveryee, these are the changes for free text date entries I mentioned in the morning, I'd suggest you review them for sanity check.
