### PR TITLE
Adding a flag for switching IP Anonimisation Off

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
@@ -18,7 +18,8 @@
   assetsPrefix: String,
   ssoUrl: Option[String],
   scriptElem: Option[Html],
-  gaCalls: Option[(String,String) => Html])
+  gaCalls: Option[(String,String) => Html],
+  analyticsAnonymizeIp: Boolean = true)
 
 @analyticsToken match {
     case Some(token@_) if !token.equals("N/A") => {
@@ -30,7 +31,7 @@
 
             @gaCalls.fold {
                 ga('create', '@token', '@analyticsHost');
-                ga('send', 'pageview', { 'anonymizeIp': true });
+                ga('send', 'pageview', { 'anonymizeIp': @analyticsAnonymizeIp });
             }{f =>
                 @f(analyticsHost, token)
             }


### PR DESCRIPTION
My team needs to switch IP Anonymisation as we need to exclude the DDCN from Analytics. However the regex we were given relies on the last octet being there. anonymizeIp = true, makes the last octet 0 so we can not exclude ourselves properly.
