### PR TITLE
Send in args as a variable argument list

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/error_notifications.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/error_notifications.scala.html
@@ -9,7 +9,7 @@
         @if(!exclusions.contains(error.key)){
         <li role="tooltip" data-journey="search-page:error:@error.key">
             <a href="#@error.key" class="error-list" data-focuses="@error.key" id="@{error.key}-error">
-                @Messages(error.message)
+                @Messages(error.message, error.args: _*)
             </a>
         </li>
         }


### PR DESCRIPTION
### Send in error.args as a variable argument list

The variables were not being sent in to the string for variable substitution
#### Before

![screen shot 2015-11-23 at 11 02 59](https://cloud.githubusercontent.com/assets/2305016/11335312/2becb22a-91d3-11e5-84d7-31daf3b79f18.png)
#### After

![screen shot 2015-11-23 at 11 04 35](https://cloud.githubusercontent.com/assets/2305016/11335318/3329053e-91d3-11e5-9e1f-adefa0ac4397.png)
