### PR TITLE
Form Refactor: error fragments in a common place

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/errorInline.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/errorInline.scala.html
@@ -3,6 +3,6 @@
 <span id="@{errorKey}-error-message"
       class="@{(Seq("error-notification") ++ classes).mkString(" ")}"
       role="alert"
-      data-journey="search-page:error:@errorKey">
+      data-input-name="@{errorKey}">
     @Messages(errorMessage)
 </span>

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/errorInline.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/errorInline.scala.html
@@ -1,0 +1,8 @@
+@(errorKey: String, errorMessage: String, classes: Seq[String] = Seq.empty)
+
+<span id="@{errorKey}-error-message"
+      class="@{(Seq("error-notification") ++ classes).mkString(" ")}"
+      role="alert"
+      data-journey="search-page:error:@errorKey">
+    @Messages(errorMessage)
+</span>

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/errorSummary.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/errorSummary.scala.html
@@ -1,0 +1,21 @@
+@(heading: String, form: Form[_], classes: Seq[String] = Seq.empty)
+
+<div class="flash error-summary@if(form.hasErrors) { error-summary--show}@classes.mkString(" ")"
+     id="error-summary-display"
+     role="alert"
+     aria-labelledby="error-summary-heading"
+     tabindex="-1">
+
+    <h2 id="error-summary-heading" class="h3-heading">@heading</h2>
+    <ul class="js-error-summary-messages">
+    @if(form.hasErrors) {
+        @form.errors.map { error =>
+            <li role="tooltip" data-journey="search-page:error:@error.key">
+                <a href="#@error.key" data-focuses="@error.key" id="@{error.key}-error-summary">
+                @Messages(error.message)
+                </a>
+            </li>
+        }
+    }
+    </ul>
+</div>

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/errorSummary.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/errorSummary.scala.html
@@ -1,17 +1,18 @@
-@(heading: String, form: Form[_], classes: Seq[String] = Seq.empty)
+@(heading: String, form: Form[_], classes: Seq[String] = Seq.empty, dataJourney: Option[String] = None)
 
-<div class="flash error-summary@if(form.hasErrors) { error-summary--show}@classes.mkString(" ")"
+<div class="flash error-summary@if(form.hasErrors) { error-summary--show} @classes.mkString(" ")"
      id="error-summary-display"
      role="alert"
      aria-labelledby="error-summary-heading"
      tabindex="-1">
-
     <h2 id="error-summary-heading" class="h3-heading">@heading</h2>
     <ul class="js-error-summary-messages">
     @if(form.hasErrors) {
         @form.errors.map { error =>
-            <li role="tooltip" data-journey="search-page:error:@error.key">
-                <a href="#@error.key" data-focuses="@error.key" id="@{error.key}-error-summary">
+            <li role="tooltip" @dataJourney.map(page => Html(s"""data-journey="${page}:error:${error.key}""""))>
+                <a href="#@error.key"
+                   id="@{error.key}-error-summary"
+                   data-focuses="@error.key">
                 @Messages(error.message)
                 </a>
             </li>


### PR DESCRIPTION
 Error fragments in a common place

The only slightly contentious thing with this PR is it is a second error summary file, although this one is different, the old one `error_notifications` is being used in many places.

![form-validation-refactor](https://cloud.githubusercontent.com/assets/2305016/12482607/7a6dead8-c048-11e5-938c-c7fc1fa882cd.gif)
