### PR TITLE
NISP-1652: move service info outside of #content 

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/main_content.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/main_content.scala.html
@@ -23,9 +23,10 @@
   getHelpForm: Html = HtmlFormat.empty)
 
 <main id="wrapper" role="main" @if(mainClass.isDefined) { class="@{mainClass.get}" } @mainDataAttributes>
-    <div id="content">
-
+    <div class="centered-content">
         @serviceInfo
+    </div>
+    <div id="content">
 
         @actingAttorneyBanner
 


### PR DESCRIPTION
# Skip Link Accessibility

On request from Chris Moore so the skip link focuses on#content rather than service info.

Related ticket NISP-1652
## Example

![skip-link](https://cloud.githubusercontent.com/assets/2305016/13470080/3f3dc77e-e0a2-11e5-85ed-3ce4da1db77f.gif)
