### PR TITLE
[GGPUNE-75] Parameter to add class to select elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,26 @@ resolvers += Resolver.bintrayRepo("hmrc", "releases")
 libraryDependencies += "uk.gov.hmrc" %% "play-ui" % "x.x.x"
 ```
 
+### How to test changes locally
+
+Publish the library locally with
+ 
+ ```sbt clean compile publishLocal```
+ 
+ This will build and install the library into your local Ivy cache. The final lines of the output will contain the version number. 
+ 
+ Then update the configuration of your frontend application to use this version number. 
+ This is in different files depending on the application. 
+ In `business-tax-account`, it is in `FrontendBuild.scala`.
+ In `one-time-password-frontend`, it is in `MicroServiceBuild.scala`.
+ The line will look like 
+ ```"uk.gov.hmrc" %% "play-ui" % "4.10"```
+ 
+ now restart your frontend application, and you will see your local changes.
+ 
+ n.b. you will need to run the sbt command to publish locally each time you make a change.
+
+
 ## License ##
  
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
@@ -27,7 +27,7 @@
         @elements.label
     </span>
     @if(elements.args.contains('_additionalTitleText)){<p>@elements.args.get('_additionalTitleText)</p>}
-    <select id="@elements.field.name" name="@elements.field.name">
+    <select id="@elements.field.name" name="@elements.field.name" class="@elements.args.get('_selectClass)">
         @if(displayEmptyValue) {
             <option>@elements.args.get('_emptyValueText)</option>
         }

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/fieldGroup.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/fieldGroup.scala.html
@@ -41,6 +41,7 @@
                                                           '_label -> select.label,
                                                           '_labelClass -> select.labelClass.getOrElse(""),
                                                           '_groupClass -> select.groupClass.getOrElse(""),
+                                                          '_selectClass -> select.selectClass.getOrElse(""),
                                                           '_additionalTitleText -> select.additionalTitleText.getOrElse(""))
                 }
                 case dateControl: uk.gov.hmrc.play.views.helpers.DateControl => {

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/model.scala
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/model.scala
@@ -34,7 +34,7 @@ object InputText {
   }
 }
 
-case class Select(values: Seq[(String, String)], emptyValueText: Option[String], label: String, labelClass: Option[String] = None, groupClass: Option[String] = None, additionalTitleText: Option[String] = None) extends FieldType
+case class Select(values: Seq[(String, String)], emptyValueText: Option[String], label: String, labelClass: Option[String] = None, groupClass: Option[String] = None, selectClass: Option[String] = None, additionalTitleText: Option[String] = None) extends FieldType
 
 case class DateControl(yearRange: Range, extraClass: Option[String] = None) extends FieldType
 


### PR DESCRIPTION
Add optional _selectClass attribute to render styles in select element on the dropdown view helper.

Usage example: 

```
@dropdown(searchTaxIdForm("taxIdType"),
                      taxIdTypes,
                      true,
                      '_selectClass -> "form-control",
                      '_emptyValueText -> "Select Tax Id Type")
```
