### PR TITLE
[GGPUNE-83] Optional inline error message placement on dropdown.

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
@@ -22,11 +22,14 @@
 
 @value = @{ field.value match { case Some(x) => x case None => "" case x => x }}
 
-<label for="@elements.field.name" class="@elements.args.get('_labelClass) @elements.args.get('_groupClass)@if(elements.hasErrors){' ' + error}">
+<label for="@elements.field.name" class="@elements.args.get('_labelClass) @elements.args.get('_groupClass)@if(elements.hasErrors){' error'}">
     <span class="label__text">
         @elements.label
     </span>
     @if(elements.args.contains('_additionalTitleText)){<p>@elements.args.get('_additionalTitleText)</p>}
+    @if(elements.args.contains('_errorsAboveInput)){
+        @elements.errors.map { error => <span style="display: block" class="error-notification">@Messages(error)</span>}
+    }
     <select id="@elements.field.name" name="@elements.field.name" class="@elements.args.get('_selectClass)">
         @if(displayEmptyValue) {
             <option>@elements.args.get('_emptyValueText)</option>
@@ -42,4 +45,6 @@
         }
     </select>
 </label>
-@elements.errors.map { error => <span style="display: block" class="error-notification">@Messages(error)</span>}
+@if(!elements.args.contains('_errorsAboveInput)){
+    @elements.errors.map { error => <span style="display: block" class="error-notification">@Messages(error)</span>}
+}


### PR DESCRIPTION
By providing _errorsAboveInput argument, the inline error message will be shown above the select input element, to aid consistency.

If the parameter is not sent, the behaviour will stay the same, with the inline error message below the input.

the error class on the label has also been fixed, as " '  ' + error " was literally rendered. now just " error" is rendered.
