### PR TITLE
PE-2198 : Need to be able to specify a "max" attribute for a "number" type input field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pids
 
 **/target/*
 target
+out
 
 **/bin/*
 **/lib/*

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/input.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/input.scala.html
@@ -74,6 +74,7 @@
         @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
         @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
         @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
+        @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
         @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
         @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
         @if(elements.args.get('_required).isDefined) { required }


### PR DESCRIPTION
For identity-verification-frontend, I needed to set the passport number field to type="number".  This field has a maximum length of 9 numbers.  To validate this, I needed to add a max="999999999" attribute to the input, which was not possible without editing input.scala.html.

![pe-2198](https://cloud.githubusercontent.com/assets/383343/15396473/369f3250-1dd4-11e6-86f4-1f856d186393.gif)
