### PR TITLE
YTA-1131: Feedback form not dynamically enforcing 2,000 character limit

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/textArea.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/textArea.scala.html
@@ -36,7 +36,8 @@
     <textarea 
     @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
     name="@elements.field.name"
-    id="@elements.field.name">@field.value</textarea>
+    id="@elements.field.name"
+    @if( elements.args.get('_maxlength) ){ maxlength="@elements.args.get('_maxlength)" }>@field.value</textarea>
     @if(labelAfter && elements.args.contains('_label)) { @elements.label }
     @if(elements.args.contains('_help)) { <small>@elements.infos</small> }
 


### PR DESCRIPTION
Allow the passing through of a _maxlength param that will be used to set the maxlength attribute of the textArea element
