### PR TITLE
YTA-1131

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/textArea.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/textArea.scala.html
@@ -25,7 +25,7 @@
 
 @labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
 
-<label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if(elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) {form-field--error}">
+<label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if(elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) {form-field--error}" @if( elements.args.get('_dataCharCounter) ){ data-char-counter="@elements.args.get('_dataCharCounter)" }>
     @elements.errors.map { error => <span class="error-notification">@Messages(error)</span>}
     @if(parentElements.isDefined) {
     @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/textArea.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/textArea.scala.html
@@ -36,7 +36,8 @@
     <textarea 
     @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
     name="@elements.field.name"
-    id="@elements.field.name">@field.value</textarea>
+    id="@elements.field.name"
+    @if( elements.args.get('_maxlength) ){ maxlength="@elements.args.get('_maxlength)" }>@field.value</textarea>
     @if(labelAfter && elements.args.contains('_label)) { @elements.label }
     @if(elements.args.contains('_help)) { <small>@elements.infos</small> }
 

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/textArea.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/textArea.scala.html
@@ -37,6 +37,7 @@
     @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
     name="@elements.field.name"
     id="@elements.field.name"
+    @if( elements.args.get('_dataCharField) ){ data-char-field="@elements.args.get('_dataCharField)" }
     @if( elements.args.get('_maxlength) ){ maxlength="@elements.args.get('_maxlength)" }>@field.value</textarea>
     @if(labelAfter && elements.args.contains('_label)) { @elements.label }
     @if(elements.args.contains('_help)) { <small>@elements.infos</small> }


### PR DESCRIPTION
Allow text area elements to enforce dynamic character limits via the 'Character Counter' component in assets frontend.

**_dataCharCounter** and **_dataCharField** parameters can now be passed through to the text area template.

_Example call (from contact frontend) to the text area template with dynamic character limit:_

``` scala
@textArea(
        feedbackForm("feedback-comments"),
        '_label -> "Comments",
        '_info -> Messages("common.feedback.information.warning"),
        '_divClass -> "form-field char-counter",
        '_inputClass -> "input--fullwidth",
        '_maxlength -> "2000",
        '_dataCharCounter -> "true",
        '_dataCharField -> "true"
        )
```

_This is what it should look like:_

![textareadynamiccharlimit](https://cloud.githubusercontent.com/assets/2510683/17555919/5281e2c6-5f09-11e6-9f7d-ec8644a3f3f1.png)
