### PR TITLE
[SDT-38] Get assetsPrefix directly from play conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ resolvers += Resolver.bintrayRepo("hmrc", "releases")
 libraryDependencies += "uk.gov.hmrc" %% "play-ui" % "x.x.x"
 ```
 
+If you require either [head](https://github.com/hmrc/play-ui/blob/master/src/main/twirl/uk/gov/hmrc/play/views/layouts/head.scala.html) or [footer](https://github.com/hmrc/play-ui/blob/master/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html) you'll also need to add some config to your `application.conf` file in order to build the complete urls for assets:
+
+```
+assets {
+  version = "x.x.x"
+  url = ""
+}
+```
+
 ### How to test changes locally
 
 Publish the library locally with

--- a/src/main/scala/uk/gov/hmrc/play/config/AssetsConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/play/config/AssetsConfig.scala
@@ -18,10 +18,10 @@ package uk.gov.hmrc.play.config
 
 import play.api.Play
 
-trait AssetsPrefix {
+trait AssetsConfig {
   lazy val assetsUrl = Play.current.configuration.getString("assets.url").getOrElse("")
   lazy val assetsVersion = Play.current.configuration.getString("assets.version").getOrElse("")
   lazy val assetsPrefix = assetsUrl + assetsVersion
 }
 
-object AssetsPrefix extends AssetsPrefix
+object AssetsConfig extends AssetsConfig

--- a/src/main/scala/uk/gov/hmrc/play/config/AssetsPrefix.scala
+++ b/src/main/scala/uk/gov/hmrc/play/config/AssetsPrefix.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.config
+
+import play.api.Play
+
+trait AssetsPrefix {
+  lazy val assetsUrl = Play.current.configuration.getString("assets.url").getOrElse("")
+  lazy val assetsVersion = Play.current.configuration.getString("assets.version").getOrElse("")
+  lazy val assetsPrefix = assetsUrl + assetsVersion
+}
+
+object AssetsPrefix extends AssetsPrefix

--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
@@ -14,7 +14,7 @@
 * limitations under the License.
 *@
 
-@import uk.gov.hmrc.play.config.AssetsPrefix
+@import uk.gov.hmrc.play.config.AssetsConfig
 
 @(analyticsToken: Option[String],
   analyticsHost: String,
@@ -44,5 +44,5 @@
     case _ => {}
 }
 <script type="text/javascript">var ssoUrl = "@ssoUrl.getOrElse("")";</script>
-<script src="@AssetsPrefix.assetsPrefix/javascripts/application.min.js" type="text/javascript"></script>
+<script src="@AssetsConfig.assetsPrefix/javascripts/application.min.js" type="text/javascript"></script>
 @scriptElem

--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
@@ -13,9 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *@
+
+@import uk.gov.hmrc.play.config.AssetsPrefix
+
 @(analyticsToken: Option[String],
   analyticsHost: String,
-  assetsPrefix: String,
   ssoUrl: Option[String],
   scriptElem: Option[Html],
   gaCalls: Option[(String,String) => Html],
@@ -42,5 +44,5 @@
     case _ => {}
 }
 <script type="text/javascript">var ssoUrl = "@ssoUrl.getOrElse("")";</script>
-<script src="@assetsPrefix/javascripts/application.min.js" type="text/javascript"></script>
+<script src="@AssetsPrefix.assetsPrefix/javascripts/application.min.js" type="text/javascript"></script>
 @scriptElem

--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/head.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/head.scala.html
@@ -13,18 +13,21 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *@
-@(assetsPrefix:String, linkElem: Option[Html], headScripts: Option[Html])
+
+@import uk.gov.hmrc.play.config.AssetsPrefix
+
+@(linkElem: Option[Html], headScripts: Option[Html])
 
 	<!--[if lt IE 8 ]>
-	<link rel='stylesheet' href='@{assetsPrefix}/stylesheets/application-ie7.min.css' />
+	<link rel='stylesheet' href='@{AssetsPrefix.assetsPrefix}/stylesheets/application-ie7.min.css' />
 	<![endif]-->
 	<!--[if IE 8 ]>
-	<link rel='stylesheet' href='@{assetsPrefix}/stylesheets/application-ie.min.css' />
+	<link rel='stylesheet' href='@{AssetsPrefix.assetsPrefix}/stylesheets/application-ie.min.css' />
 	<![endif]-->
 	<!--[if gt IE 8]><!-->
-	<link rel='stylesheet' href='@{assetsPrefix}/stylesheets/application.min.css' />
+	<link rel='stylesheet' href='@{AssetsPrefix.assetsPrefix}/stylesheets/application.min.css' />
 	<!--<![endif]-->
 
-	<script src='@{assetsPrefix}/javascripts/vendor/modernizr.js' type='text/javascript'></script>
+	<script src='@{AssetsPrefix.assetsPrefix}/javascripts/vendor/modernizr.js' type='text/javascript'></script>
 @headScripts
 @linkElem

--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/head.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/head.scala.html
@@ -14,20 +14,20 @@
 * limitations under the License.
 *@
 
-@import uk.gov.hmrc.play.config.AssetsPrefix
+@import uk.gov.hmrc.play.config.AssetsConfig
 
 @(linkElem: Option[Html], headScripts: Option[Html])
 
 	<!--[if lt IE 8 ]>
-	<link rel='stylesheet' href='@{AssetsPrefix.assetsPrefix}/stylesheets/application-ie7.min.css' />
+	<link rel='stylesheet' href='@{AssetsConfig.assetsPrefix}/stylesheets/application-ie7.min.css' />
 	<![endif]-->
 	<!--[if IE 8 ]>
-	<link rel='stylesheet' href='@{AssetsPrefix.assetsPrefix}/stylesheets/application-ie.min.css' />
+	<link rel='stylesheet' href='@{AssetsConfig.assetsPrefix}/stylesheets/application-ie.min.css' />
 	<![endif]-->
 	<!--[if gt IE 8]><!-->
-	<link rel='stylesheet' href='@{AssetsPrefix.assetsPrefix}/stylesheets/application.min.css' />
+	<link rel='stylesheet' href='@{AssetsConfig.assetsPrefix}/stylesheets/application.min.css' />
 	<!--<![endif]-->
 
-	<script src='@{AssetsPrefix.assetsPrefix}/javascripts/vendor/modernizr.js' type='text/javascript'></script>
+	<script src='@{AssetsConfig.assetsPrefix}/javascripts/vendor/modernizr.js' type='text/javascript'></script>
 @headScripts
 @linkElem


### PR DESCRIPTION
This enforces a standardised way of defining assets config in frontends and moves away from the run mode structure.

This is for review by @hmrc/platops 
