### PR TITLE
Allow AssetsConfig and OptimizelyConfig to be passed into templates

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
@@ -22,7 +22,8 @@
   scriptElem: Option[Html],
   gaCalls: Option[(String,String) => Html],
   analyticsAnonymizeIp: Boolean = true,
-  analyticsAdditionalJs: Option[Html] = None)
+  analyticsAdditionalJs: Option[Html] = None
+)(implicit assetsConfig: AssetsConfig = AssetsConfig)
 
 @analyticsToken match {
     case Some(token@_) if !token.equals("N/A") => {
@@ -44,5 +45,5 @@
     case _ => {}
 }
 <script type="text/javascript">var ssoUrl = "@ssoUrl.getOrElse("")";</script>
-<script src="@AssetsConfig.assetsPrefix/javascripts/application.min.js" type="text/javascript"></script>
+<script src="@assetsConfig.assetsPrefix/javascripts/application.min.js" type="text/javascript"></script>
 @scriptElem

--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/head.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/head.scala.html
@@ -15,22 +15,25 @@
 *@
 
 @import uk.gov.hmrc.play.config.AssetsConfig
-@import uk.gov.hmrc.play.config.OptimizelyConfig._
+@import uk.gov.hmrc.play.config.OptimizelyConfig
 
-@(linkElem: Option[Html], headScripts: Option[Html])
+@(linkElem: Option[Html],
+  headScripts: Option[Html]
+)(implicit assetsConfig: AssetsConfig = AssetsConfig,
+  optimizelyConfig: OptimizelyConfig = OptimizelyConfig)
 
 	<!--[if lt IE 8 ]>
-	<link rel='stylesheet' href='@{AssetsConfig.assetsPrefix}/stylesheets/application-ie7.min.css' />
+	<link rel='stylesheet' href='@{assetsConfig.assetsPrefix}/stylesheets/application-ie7.min.css' />
 	<![endif]-->
 	<!--[if IE 8 ]>
-	<link rel='stylesheet' href='@{AssetsConfig.assetsPrefix}/stylesheets/application-ie.min.css' />
+	<link rel='stylesheet' href='@{assetsConfig.assetsPrefix}/stylesheets/application-ie.min.css' />
 	<![endif]-->
 	<!--[if gt IE 8]><!-->
-	<link rel='stylesheet' href='@{AssetsConfig.assetsPrefix}/stylesheets/application.min.css' />
+	<link rel='stylesheet' href='@{assetsConfig.assetsPrefix}/stylesheets/application.min.css' />
 	<!--<![endif]-->
 
-	@optimizelySnippet(optimizelyBaseUrl, optimizelyProjectId)
-	<script src='@{AssetsConfig.assetsPrefix}/javascripts/vendor/modernizr.js' type='text/javascript'></script>
+	@optimizelySnippet(optimizelyConfig.optimizelyBaseUrl, optimizelyConfig.optimizelyProjectId)
+	<script src='@{assetsConfig.assetsPrefix}/javascripts/vendor/modernizr.js' type='text/javascript'></script>
 
 @headScripts
 @linkElem

--- a/src/test/scala/uk/gov/hmrc/play/views/layouts/TestWithoutPlayAppSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/layouts/TestWithoutPlayAppSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.views.layouts
+
+import org.scalatest.{Matchers, WordSpec}
+import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout}
+import uk.gov.hmrc.play.views
+import uk.gov.hmrc.play.views.layouts.test.{TestAssetsConfig, TestOptimizelyConfig}
+
+class TestWithoutPlayAppSpec extends WordSpec with Matchers {
+
+  "Header and Footer templates that use Play configuration" should {
+    "be renderable without a started Play application" in {
+      val rendered = contentAsString(views.html.layouts.test_header_footer_includes()(TestAssetsConfig, TestOptimizelyConfig))
+
+      rendered should include("head was rendered")
+      rendered should include("footer was rendered")
+    }
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/play/views/layouts/test/TestAssetsConfig.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/layouts/test/TestAssetsConfig.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.views.layouts.test
+
+import uk.gov.hmrc.play.config.AssetsConfig
+
+object TestAssetsConfig extends AssetsConfig {
+  override lazy val assetsUrl: String = "http://localhost:9000/assets/"
+  override lazy val assetsVersion: String = "2.149.0"
+}

--- a/src/test/scala/uk/gov/hmrc/play/views/layouts/test/TestOptimizelyConfig.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/layouts/test/TestOptimizelyConfig.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.views.layouts.test
+
+import uk.gov.hmrc.play.config.OptimizelyConfig
+
+object TestOptimizelyConfig extends OptimizelyConfig {
+  override lazy val optimizelyBaseUrl = ""
+  override lazy val optimizelyProjectId = None
+}

--- a/src/test/twirl/uk/gov/hmrc/play/views/layouts/test_header_footer_includes.scala.html
+++ b/src/test/twirl/uk/gov/hmrc/play/views/layouts/test_header_footer_includes.scala.html
@@ -1,0 +1,28 @@
+@import uk.gov.hmrc.play.config.OptimizelyConfig
+@import uk.gov.hmrc.play.config.AssetsConfig
+@()(implicit assetsConfig: AssetsConfig, optimizelyConfig: OptimizelyConfig)
+
+@*
+The HTML produced by this template just needs to include the templates which
+use configuration to ensure that they can be rendered in tests without a
+running Play application
+*@
+
+@headScripts = {
+  head was rendered
+}
+
+@footerScriptElem = {
+  footer was rendered
+}
+
+@head(
+  linkElem = None,
+  headScripts = Some(headScripts))
+
+@footer(
+  analyticsToken = None,
+  analyticsHost = "",
+  ssoUrl = None,
+  scriptElem = Some(footerScriptElem),
+  gaCalls = None)


### PR DESCRIPTION
This allows controllers that use these templates to be unit tested without a running Play application, by passing in test AssetsConfig and OptimizelyConfig implementations that do not use the Play config. For an example of how to do this see https://github.com/hmrc/agent-subscription-frontend/blob/no-play-app-in-unit-test/test/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionControllerSpec.scala

N.B. I think a new major version will be needed after this change because I don't think it's binary compatible. It adds new arguments to `footer.scala.html` and `head.scala.html`, although they do have default values so most users of the library will just need to be recompiled.