### PR TITLE
Make sure there is really no started Play app during TestWithoutPlayAppSpec

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -51,6 +51,7 @@ object HmrcBuild extends Build {
     )
     .settings(TwirlKeys.templateImports ++= Seq("play.api.mvc._", "play.api.data._", "play.api.i18n._", "play.api.templates.PlayMagic._"))
     .settings(unmanagedSourceDirectories in sbt.Compile += baseDirectory.value / "src/main/twirl")
+    .settings(parallelExecution in sbt.Test := false)
 }
 
 object Dependencies {

--- a/src/test/scala/uk/gov/hmrc/play/views/layouts/TestWithoutPlayAppSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/layouts/TestWithoutPlayAppSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.play.views.layouts
 
 import org.scalatest.{Matchers, WordSpec}
+import play.api.Play
 import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout}
 import uk.gov.hmrc.play.views
 import uk.gov.hmrc.play.views.layouts.test.{TestAssetsConfig, TestOptimizelyConfig}
@@ -27,9 +28,16 @@ class TestWithoutPlayAppSpec extends WordSpec with Matchers {
     "be renderable without a started Play application" in {
       val rendered = contentAsString(views.html.layouts.test_header_footer_includes()(TestAssetsConfig, TestOptimizelyConfig))
 
+      thereShouldBeNoStartedPlayApp()
+
       rendered should include("head was rendered")
       rendered should include("footer was rendered")
     }
   }
 
+  private def thereShouldBeNoStartedPlayApp() = {
+    intercept[RuntimeException] {
+      Play.current
+    }.getMessage should include("no started application")
+  }
 }


### PR DESCRIPTION
This makes sure that no Play app has been started by another test running in parallel with TestWithoutPlayAppSpec.