### PR TITLE
adding support for 'min' attribute of html5 input

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/input.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/input.scala.html
@@ -74,6 +74,7 @@
         @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
         @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
         @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
+        @if(elements.args.get('_min).isDefined) { min="@elements.args.get('_min)" }
         @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
         @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
         @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }


### PR DESCRIPTION
just as 'max' html5 attribute is supported, added support for 'min' attribute
https://www.w3.org/TR/html5/forms.html#attr-input-min