### PR TITLE
Display checkbox checked attribute correctly

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/singleCheckbox.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/singleCheckbox.scala.html
@@ -19,11 +19,12 @@
 @import views.html.helper._
 
 @elements = @{ new FieldElements(field.id, field, null, args.toMap, messages) }
+@value = @{ field.value match { case Some(x) => x case None => "false" case x => x }}
 
-<label class="form-field-single@field.value.map{ v => selected }@if(elements.args.get('_labelClass)){ @elements.args.get('_labelClass) }@if(elements.hasErrors){ error form-field--error }" for="@elements.id">
+<label class="form-field-single @if(value == "true"){ selected } @if(elements.args.get('_labelClass)){ @elements.args.get('_labelClass) }@if(elements.hasErrors){ error form-field--error }" for="@elements.id">
     @elements.errors.map { error =>
         <span id="@{elements.field.id}--error" class="error-notification" style="display: block">@Messages(error)</span>
     }
     @elements.label
-    <input type="checkbox" id="@elements.id" name="@elements.field.name" value="true" @field.value.map{ v => checked="checked" } @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }>
+    <input type="checkbox" id="@elements.id" name="@elements.field.name" value="true" @if(value == "true"){ checked="checked" } @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }>
 </label>

--- a/src/test/scala/uk/gov/hmrc/play/views/helpers/SingleCheckboxSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/helpers/SingleCheckboxSpec.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.views.helpers
+
+import org.jsoup.Jsoup
+import org.scalatest.{Matchers, WordSpec}
+import play.api.data.Form
+import play.api.data.Forms.{mapping, _}
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.views.html.helpers.singleCheckbox
+import play.api.i18n.Messages.Implicits._
+
+class SingleCheckboxSpec extends WordSpec with Matchers {
+
+  implicit val application = new GuiceApplicationBuilder().build()
+
+  case class DummyFormData(exampleCheckbox: Option[Boolean])
+
+  def dummyForm = Form(
+    mapping(
+      "exampleCheckbox" -> optional(boolean)
+    )(DummyFormData.apply)(DummyFormData.unapply))
+
+  "Have the checked attribute when value is 'true'" in {
+
+    val WithTrueCheckboxValueForm = dummyForm.fill(DummyFormData(Some(true)))
+    val doc = Jsoup.parse(
+      contentAsString(
+        singleCheckbox(
+          WithTrueCheckboxValueForm("exampleCheckbox"),
+          '_label -> "exampleLabel",
+          '_inputClass -> "inputClass",
+          '_labelClass -> "labelClass"
+        )
+      )
+    )
+
+    val checkboxElement = doc.getElementById("exampleCheckbox")
+    val labelElement = doc.select("label")
+
+    checkboxElement.hasAttr("checked") shouldBe true
+    checkboxElement.attr("checked") shouldBe "checked"
+    checkboxElement.hasClass("inputClass") shouldBe true
+    labelElement.text() shouldBe "exampleLabel"
+    labelElement.hasClass("labelClass") shouldBe true
+    labelElement.hasClass("selected") shouldBe true
+  }
+
+  "The Single CheckBox" should {
+    "Not have the checked attribute when value is 'None'" in {
+
+      val doc = Jsoup.parse(
+        contentAsString(
+          singleCheckbox(
+            dummyForm("exampleCheckbox"),
+            '_label -> "exampleLabel",
+            '_inputClass -> "inputClass",
+            '_labelClass -> "labelClass"
+          )
+        )
+      )
+
+      val checkboxElement = doc.getElementById("exampleCheckbox")
+      val labelElement = doc.select("label")
+
+      checkboxElement.hasAttr("checked") shouldBe false
+      checkboxElement.hasClass("inputClass") shouldBe true
+      labelElement.text() shouldBe "exampleLabel"
+      labelElement.hasClass("labelClass") shouldBe true
+      labelElement.hasClass("selected") shouldBe false
+    }
+
+    "Not have the checked attribute when value is 'false'" in {
+      val WithFalseCheckboxValueForm = dummyForm.fill(DummyFormData(Some(false)))
+      val doc = Jsoup.parse(
+        contentAsString(
+          singleCheckbox(
+            WithFalseCheckboxValueForm("exampleCheckbox"),
+            '_label -> "exampleLabel",
+            '_inputClass -> "inputClass",
+            '_labelClass -> "labelClass"
+          )
+        )
+      )
+
+      val checkboxElement = doc.getElementById("exampleCheckbox")
+      val labelElement = doc.select("label")
+
+      checkboxElement.hasAttr("checked") shouldBe false
+      checkboxElement.hasClass("inputClass") shouldBe true
+      labelElement.text() shouldBe "exampleLabel"
+      labelElement.hasClass("labelClass") shouldBe true
+      labelElement.hasClass("selected") shouldBe false
+    }
+  }
+}


### PR DESCRIPTION
## Problem 
Work in a previous [PR](https://github.com/hmrc/play-ui/pull/64) changed the way the `field.value` property works in the`singleCheckbox` html fragment. 

## Fix 
- Revert the `@value` variable creation/assignment code
- Add tests

@gianick and @thoeni can one of you confirm this is working as intended and I will get the patch released. Thanks


