### PR TITLE
Fixed issue with checkbox input appearing after the label.

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/singleCheckbox.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/singleCheckbox.scala.html
@@ -25,6 +25,6 @@
     @elements.errors.map { error =>
         <span id="@{elements.field.id}--error" class="error-notification" style="display: block">@Messages(error)</span>
     }
-    @elements.label
     <input type="checkbox" id="@elements.id" name="@elements.field.name" value="true" @if(value == "true"){ checked="checked" } @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }>
+    @elements.label
 </label>


### PR DESCRIPTION
When the single checkbox is used without the `block-label` class, the `label` appears before the `input` as shown in the screenshot below:
![blabla1](https://cloud.githubusercontent.com/assets/8497852/23999171/69bbdeb4-0a4f-11e7-8b22-664141c2a775.png)

The `label` in the singleCheckbox.scala.html helper has now been placed after the `input` and the checkbox appears before the label as shown below:
![blabla-2](https://cloud.githubusercontent.com/assets/8497852/23999176/6ebdccc4-0a4f-11e7-884a-7f0a9760ac3f.png)
