### PR TITLE
Update helper to adopt markup for new radio buttons for new styling

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/inputRadioGroup.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/inputRadioGroup.scala.html
@@ -32,18 +32,7 @@
 
 @radioOptions.map { case (value, label) =>
     @defining(s"${elements.field.name}-${value.toLowerCase.replace(" ","_")}")  { inputId =>
-        <label for="@inputId"
-            @elements.args.get('_labelClass).map{labelClass => class="@labelClass@field.value.filter( _ == value).map{_ => selected}"}>
-            @if(!labelAfter) {
-                @if(elements.args.get('_stackedLabel)) {
-                    @if(label.split(" ").length < 2) {<br>@label
-                    } else {
-                        @for( (l, index) <- label.split(" ").zipWithIndex) {
-                            @if(index != 0) {<br>}@l
-                        }
-                    }
-                } else { @label }
-            }
+        <div class="multiple-choice">
             <input
                 type="radio"
                 id="@inputId"
@@ -52,17 +41,32 @@
                 @elements.args.get('_inputClass).map{inputClass => class="@inputClass"}
                 @if(elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
                 @field.value.filter( _ == value).map{_ => checked="checked"}/>
-            @if(labelAfter) {
-                @if(elements.args.get('_stackedLabel)) {
-                    @if(label.split(" ").length < 2) {<br>@label
-                    } else {
-                        @for( (l, index) <- label.split(" ").zipWithIndex) {
-                            @if(index != 0) {<br>}@l
+                
+            <label for="@inputId"
+                @elements.args.get('_labelClass).map{labelClass => class="@labelClass@field.value.filter( _ == value).map{_ => selected}"}>
+                @if(!labelAfter) {
+                    @if(elements.args.get('_stackedLabel)) {
+                        @if(label.split(" ").length < 2) {<br>@label
+                        } else {
+                            @for( (l, index) <- label.split(" ").zipWithIndex) {
+                                @if(index != 0) {<br>}@l
+                            }
                         }
-                    }
-                } else { @label }
-            }
-        </label>
+                    } else { @label }
+                }
+
+                @if(labelAfter) {
+                    @if(elements.args.get('_stackedLabel)) {
+                        @if(label.split(" ").length < 2) {<br>@label
+                        } else {
+                            @for( (l, index) <- label.split(" ").zipWithIndex) {
+                                @if(index != 0) {<br>}@l
+                            }
+                        }
+                    } else { @label }
+                }
+            </label>
+        </div>
     }
 }
 </fieldset>

--- a/src/test/scala/uk/gov/hmrc/play/views/helpers/InputRadioGroupSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/helpers/InputRadioGroupSpec.scala
@@ -83,7 +83,7 @@ class InputRadioGroupSpec extends WordSpec with Matchers {
       val radioGroupField = radioGroupFieldset.getElementsByTag("label").first()
       radioGroupField.attr("class") should include("myLabelClass")
       radioGroupField.ownText() shouldBe "myLabel"
-      val radioGroupFieldInput = radioGroupField.getElementsByTag("input")
+      val radioGroupFieldInput = radioGroupFieldset.getElementsByTag("input")
       radioGroupFieldInput.attr("class") shouldBe "inputClass"
     }
 


### PR DESCRIPTION
This commit includes:
• Removing the input from inside the label and placing it above and adjacent to the label
• Wrapping the input and label in div with .multiple-choice class

This changes relies on the addition of the styles added to the HMRC AF
Which is in this pull request
https://github.com/hmrc/assets-frontend/pull/789 (update: this pull request has now been merged, a bump to latest or at least HMRC AF frontend release/2.247.0, will be required to make this change effective)
https://github.com/hmrc/assets-frontend/releases/tag/release%2F2.247.0

Therefore it would be unwise to merge this until the above pull request has been merged