### PR TITLE
SDT-719 / DDCOPS-3415 Strip query strings from GA page payload

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
@@ -36,6 +36,7 @@
             @gaCalls.fold {
                 ga('create', '@token', '@analyticsHost');
                 @analyticsAdditionalJs
+                ga('set',  'page', location.pathname);
                 ga('send', 'pageview', { 'anonymizeIp': @analyticsAnonymizeIp });
             }{f =>
                 @f(analyticsHost, token)

--- a/src/test/scala/uk/gov/hmrc/play/views/layouts/FooterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/layouts/FooterSpec.scala
@@ -37,5 +37,17 @@ class FooterSpec extends WordSpec with Matchers with StartedPlayApp {
 
       rendered should include("footer was rendered")
     }
+
+    "remove the query string from the page data item" in {
+      val rendered = contentAsString(views.html.layouts.footer(
+        analyticsToken = Some("TESTTOKEN"),
+        analyticsHost = "localhost",
+        ssoUrl = Some("localhost"),
+        scriptElem = None,
+        gaCalls = None)(TestAssetsConfig))
+
+      rendered should include("ga('set',  'page', location.pathname);")
+    }
+
   }
 }


### PR DESCRIPTION
SDT-719 DDCOPS-3415 Ensure query strings are not included in the 'page' data sent to Google Analytics