### PR TITLE
SDT-721 Optionally allow Query Strings in Google Analytics

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/footer.scala.html
@@ -22,7 +22,8 @@
   scriptElem: Option[Html],
   gaCalls: Option[(String,String) => Html],
   analyticsAnonymizeIp: Boolean = true,
-  analyticsAdditionalJs: Option[Html] = None
+  analyticsAdditionalJs: Option[Html] = None,
+  allowQueryStringInAnalytics: Boolean = false
 )(implicit assetsConfig: AssetsConfig = AssetsConfig)
 
 @analyticsToken match {
@@ -36,7 +37,10 @@
             @gaCalls.fold {
                 ga('create', '@token', '@analyticsHost');
                 @analyticsAdditionalJs
+
+                @if(!allowQueryStringInAnalytics){
                 ga('set',  'page', location.pathname);
+                }
                 ga('send', 'pageview', { 'anonymizeIp': @analyticsAnonymizeIp });
             }{f =>
                 @f(analyticsHost, token)

--- a/src/test/scala/uk/gov/hmrc/play/views/layouts/FooterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/layouts/FooterSpec.scala
@@ -38,7 +38,7 @@ class FooterSpec extends WordSpec with Matchers with StartedPlayApp {
       rendered should include("footer was rendered")
     }
 
-    "remove the query string from the page data item" in {
+    "remove the query string by default from the page data item" in {
       val rendered = contentAsString(views.html.layouts.footer(
         analyticsToken = Some("TESTTOKEN"),
         analyticsHost = "localhost",
@@ -49,5 +49,16 @@ class FooterSpec extends WordSpec with Matchers with StartedPlayApp {
       rendered should include("ga('set',  'page', location.pathname);")
     }
 
+    "allow the query string by exception in the page data item" in {
+      val rendered = contentAsString(views.html.layouts.footer(
+        analyticsToken = Some("TESTTOKEN"),
+        analyticsHost = "localhost",
+        ssoUrl = Some("localhost"),
+        scriptElem = None,
+        allowQueryStringInAnalytics = true,
+        gaCalls = None)(TestAssetsConfig))
+
+      rendered should not include("ga('set',  'page', location.pathname);")
+    }
   }
 }


### PR DESCRIPTION
SDT-721 Add a Boolean parameter to the footer fragment to allow query strings in Google Analytics