### PR TITLE
fixed space in beta banner link

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/betaBanner.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/betaBanner.scala.html
@@ -27,7 +27,7 @@
                 <a id="feedback-link"
                 href="@linkUrl"
                 data-sso="false"
-                data-journey-click="other-global:Click:Feedback">@Messages("label.beta.feedback") </a>@Messages("label.beta.improve")
+                data-journey-click="other-global:Click:Feedback">@Messages("label.beta.feedback")</a> @Messages("label.beta.improve")
             }
         }
     </span>


### PR DESCRIPTION
At the moment the beta banner includes link which includes a space which is a bit ugly - I've removed that space from the link in this PR