### PR TITLE
PLATY-252 Ability to specify back url in beta feedback link

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/betaBanner.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/betaBanner.scala.html
@@ -13,22 +13,29 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *@
+
+@import views.html.helper
+
 @(userLoggedIn: Boolean,
         betaFeedbackUrl: String,
         betaFeedbackUnauthenticatedUrl: String,
         showFeedbackLinkInBetaBanner: Boolean = true,
+        backUrl: Option[String] = None,
         noBorder: Boolean = false)(implicit messages: Messages)
 
 <div class="beta-banner @if(noBorder) {beta-banner--borderless}">
     <p>
         <strong class="phase-tag">@Messages("label.beta")</strong>
         <span>@Messages("label.beta.newservice") @if(showFeedbackLinkInBetaBanner) {
-              @Messages("label.beta.yours") @defining(if (userLoggedIn) betaFeedbackUrl else betaFeedbackUnauthenticatedUrl) { linkUrl =>
-                <a id="feedback-link"
-                href="@linkUrl"
-                data-sso="false"
-                data-journey-click="other-global:Click:Feedback">@Messages("label.beta.feedback") </a>@Messages("label.beta.improve")
-            }
+              @Messages("label.beta.yours")
+                @defining(if (userLoggedIn) betaFeedbackUrl else betaFeedbackUnauthenticatedUrl) { linkUrl =>
+                @defining(returnUrl match { case Some(url) => linkUrl + "?backUrl=" + helper.urlEncode(url) case None => linkUrl }) { linkUrlWithReturn =>
+                    <a id="feedback-link"
+                    href="@linkUrlWithReturn"
+                    data-sso="false"
+                    data-journey-click="other-global:Click:Feedback">@Messages("label.beta.feedback") </a>@Messages("label.beta.improve")
+                }
+                }
         }
     </span>
     </p>

--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/betaBanner.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/betaBanner.scala.html
@@ -29,7 +29,7 @@
         <span>@Messages("label.beta.newservice") @if(showFeedbackLinkInBetaBanner) {
               @Messages("label.beta.yours")
                 @defining(if (userLoggedIn) betaFeedbackUrl else betaFeedbackUnauthenticatedUrl) { linkUrl =>
-                @defining(returnUrl match { case Some(url) => linkUrl + "?backUrl=" + helper.urlEncode(url) case None => linkUrl }) { linkUrlWithReturn =>
+                @defining(backUrl match { case Some(url) => linkUrl + "?backUrl=" + helper.urlEncode(url) case None => linkUrl }) { linkUrlWithReturn =>
                     <a id="feedback-link"
                     href="@linkUrlWithReturn"
                     data-sso="false"


### PR DESCRIPTION
In a contact-frontend service which handles beta feedbacks we implemented ability to provide an optional return url.
If the return url is present, the feedback confirmation page will contain "Back" button redirecting to this link.