### PR TITLE
Move error hint under label in helpers.input

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/input.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/input.scala.html
@@ -29,20 +29,6 @@
 
 <label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if(elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) {form-field--error}" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
 
-    @if(!elements.args.contains('_hideErrors)) {
-        @elements.errors.map { error =>
-              <span class="error-notification"
-                  @if(elements.args.contains('_error_id)) {
-                        id="@elements.args.get('_error_id)"
-                  }
-                  role="tooltip"
-                  data-journey="search-page:error:@elements.field.name">
-                  @Messages(error)
-              </span>
-        }
-    }
-
-
     @if(parentElements.isDefined) {
         @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}
     }
@@ -63,6 +49,20 @@
         @if(labelHighlight){</strong>}
 
     }
+
+    @if(!elements.args.contains('_hideErrors)) {
+        @elements.errors.map { error =>
+        <span class="error-notification"
+            @if(elements.args.contains('_error_id)) {
+                id="@elements.args.get('_error_id)"
+            }
+            role="tooltip"
+            data-journey="search-page:error:@elements.field.name">
+            @Messages(error)
+        </span>
+        }
+    }
+
     <input
         @if( elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
         @if( elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}

--- a/src/test/scala/uk/gov/hmrc/play/views/helpers/InputSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/helpers/InputSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.views.helpers
+
+import org.jsoup.Jsoup
+import org.scalatest.{Matchers, WordSpec}
+import play.api.data.{Field, Form, FormError}
+import play.api.data.Forms.{mapping, text}
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.Helpers.contentAsString
+import play.api.i18n.Messages.Implicits._
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.views.html.helpers.input
+import scala.collection.JavaConverters._
+
+
+class InputSpec extends WordSpec with Matchers {
+
+  implicit val application = new GuiceApplicationBuilder().build()
+
+  case class DummyFormData(inputBoxValue: String)
+
+  def dummyForm = Form(
+    mapping(
+      "inputBoxValue" -> text
+
+    )(DummyFormData.apply)(DummyFormData.unapply))
+
+  "@helpers.input" should {
+    "render an input box" in {
+      val doc = Jsoup.parse(contentAsString(input(field = dummyForm("inputValue"),'_inputClass -> "myInputClass", '_label -> "myLabel")))
+      val inputBox = doc.getElementById("inputValue")
+
+      inputBox.attr("type") shouldBe "text"
+      inputBox.attr("name") shouldBe "inputValue"
+      inputBox.attr("value") shouldBe ""
+      inputBox.attr("class") shouldBe "myInputClass"
+      inputBox.parent().text() shouldBe "myLabel"
+    }
+
+    "render error notification when errors are present" in {
+      val doc = Jsoup.parse(contentAsString(input(
+        field = Field(dummyForm, "", Seq.empty, None, Seq(FormError("inputBoxValue", "Enter a value")), Some("")),
+        '_inputClass -> "myInputClass", '_label -> "myLabel", '_error_id -> "myError")))
+      val errorMessage = doc.getElementById("myError").text
+      errorMessage shouldBe "Enter a value"
+    }
+
+    "render input box with errors in the right order" in {
+      val doc = Jsoup.parse(contentAsString(input(
+        field = Field(dummyForm, "", Seq.empty, None, Seq(FormError("inputBoxValue", "Form Error Text")), Some("")),
+        '_inputClass -> "inputClass",
+        '_label -> "Label Text",
+        '_error_id -> "errorId",
+        '_inputHint -> "Input Hint Text",
+        '_labelClass -> "myLabelClass")
+      ))
+      val inputBox = doc.getElementsByClass("myLabelClass").first
+      val listOfInputBoxTextInOrder = inputBox.getElementsByTag("span").asScala.toList.map(_.text)
+
+      listOfInputBoxTextInOrder shouldBe List("Label Text", "Input Hint Text", "Form Error Text")
+    }
+  }
+
+}


### PR DESCRIPTION
This is based on GOV.uk standards as shown on http://govuk-elements.herokuapp.com/form-elements/example-form-elements/ (21-12-17)

Spec added for input as there was not an existing spec.

## Screenshot of current implementation of helpers.input
<img width="1041" alt="errormessageabovelabel-beforefix" src="https://user-images.githubusercontent.com/17781505/34262234-b7168bf0-e663-11e7-9c2b-1c0bb4a559c1.png">

## Screenshot of new implementation of helpers.input
<img width="936" alt="errormessagebelowlabel-afterfix" src="https://user-images.githubusercontent.com/17781505/34262206-9653f68c-e663-11e7-96d4-29b1c9ebc8a9.png">

