### PR TITLE
Added a value attribute to optional initially selected option

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
@@ -34,7 +34,7 @@
 }
 <select id="@elements.field.name" name="@elements.field.name" class="@elements.args.get('_selectClass)">
     @if(displayEmptyValue) {
-        <option>@elements.args.get('_emptyValueText)</option>
+        <option value="@elements.args.get('_emptyValue)">@elements.args.get('_emptyValueText)</option>
     }
     @for(option <- elementOptions) {
         <option

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
@@ -34,7 +34,7 @@
 }
 <select id="@elements.field.name" name="@elements.field.name" class="@elements.args.get('_selectClass)">
     @if(displayEmptyValue) {
-        <option value="@elements.args.get('_emptyValue)">@elements.args.get('_emptyValueText)</option>
+        <option value="">@elements.args.get('_emptyValueText)</option>
     }
     @for(option <- elementOptions) {
         <option

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
@@ -34,7 +34,7 @@
 }
 <select id="@elements.field.name" name="@elements.field.name" class="@elements.args.get('_selectClass)">
     @if(displayEmptyValue) {
-        <option @if(elements.args.get('_includeValueAttribute)) {value=""}>@elements.args.get('_emptyValueText)</option>
+        <option value="">@elements.args.get('_emptyValueText)</option>
     }
     @for(option <- elementOptions) {
         <option

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/dropdown.scala.html
@@ -34,7 +34,7 @@
 }
 <select id="@elements.field.name" name="@elements.field.name" class="@elements.args.get('_selectClass)">
     @if(displayEmptyValue) {
-        <option value="">@elements.args.get('_emptyValueText)</option>
+        <option @if(elements.args.get('_includeValueAttribute)) {value=""}>@elements.args.get('_emptyValueText)</option>
     }
     @for(option <- elementOptions) {
         <option


### PR DESCRIPTION
added a value to the optional initial <option>

Before:
```
<option>@elements.args.get('_emptyValueText)</option>
```

After:
```
<option value="">@elements.args.get('_emptyValueText)</option>
```

This change will allow the initial option's value to be set to nothing rather than the "_emptyValueText" as the text content of an option is used in the absence of a value attribute. This will make validation easier as we can just check for an empty value on a required field.
This change will potentially break tests and form validation where a play-ui dropdown has already been used in projects. 