### PR TITLE
Fix backwards compatiblity

### DIFF
--- a/src/main/play-25/uk/gov/hmrc/play/config.scala
+++ b/src/main/play-25/uk/gov/hmrc/play/config.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play
+
+import play.api.Play
+
+package object config {
+
+  // for backwards compatibility with previous versions where AssetsConfig was an object
+  lazy val AssetsConfig: AssetsConfig = Play.current.injector.instanceOf[AssetsConfig]
+
+  // for backwards compatibility with previous versions where OptimizelyConfig was an object
+  lazy val OptimizelyConfig: OptimizelyConfig = Play.current.injector.instanceOf[OptimizelyConfig]
+
+}

--- a/src/main/play-26/uk/gov/hmrc/play/config.scala
+++ b/src/main/play-26/uk/gov/hmrc/play/config.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play
+
+import play.api.Play
+
+package object config {
+
+  @deprecated("Use DI", "7.26.0")
+  lazy val AssetsConfig: AssetsConfig = Play.current.injector.instanceOf[AssetsConfig]
+
+  @deprecated("Use DI", "7.26.0")
+  lazy val OptimizelyConfig: OptimizelyConfig = Play.current.injector.instanceOf[OptimizelyConfig]
+
+}

--- a/src/test/scala/uk/gov/hmrc/play/views/helpers/BackwardsCompatibilitySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/helpers/BackwardsCompatibilitySpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.{Matchers, WordSpec}
 
 /*
  * Verifies that old pre play 2.6 way of accessing templates
- * continues to work after we made the injectable.
+ * continues to work after we've made them injectable.
  */
 class BackwardsCompatibilitySpec extends WordSpec with Matchers {
 

--- a/src/test/scala/uk/gov/hmrc/play/views/layouts/BackwardsCompatibilitySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/views/layouts/BackwardsCompatibilitySpec.scala
@@ -18,6 +18,10 @@ package uk.gov.hmrc.play.views.layouts
 
 import org.scalatest.{Matchers, WordSpec}
 
+/*
+ * Verifies that old pre play 2.6 way of accessing templates
+ * continues to work after we've made them injectable.
+ */
 class BackwardsCompatibilitySpec extends WordSpec with Matchers {
 
   import uk.gov.hmrc.play.views.html.layouts._


### PR DESCRIPTION
`AssetsConfig` and `OptimizelyConfig` where previously objects and we broke backwards compatibility in `7.23.0` by converting to a class. This brings back the compatibility.