### PR TITLE
Remove role=tooltip

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/ErrorSummary.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/ErrorSummary.scala.html
@@ -27,7 +27,7 @@
         <h2 id="error-summary-heading" class="h3-heading">@heading</h2>
         <ul class="js-error-summary-messages">
         @form.errors.map { error =>
-            <li role="tooltip" @dataJourney.map(page => Html(s"""data-journey="${page}:error:${error.key}""""))>
+            <li @dataJourney.map(page => Html(s"""data-journey="${page}:error:${error.key}""""))>
                 <a href="#@error.key"
                 id="@{
                     error.key


### PR DESCRIPTION
Role tooltip causes an error in an accessibility scan, the newer version of the error summary doesn't use this https://design-system.service.gov.uk/components/error-summary/..