### PR TITLE
SDT-996 Add Optional EU Exit links to the Footer

### DIFF
--- a/src/main/play-25/uk/gov/hmrc/play/views/html/layouts/layouts.scala
+++ b/src/main/play-25/uk/gov/hmrc/play/views/html/layouts/layouts.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ package object layouts {
   lazy val attorney_banner = new AttorneyBanner()
   lazy val betaBanner = new BetaBanner()
   lazy val footer = new Footer(assetsConfig)
+  lazy val eu_exit_links = new EuExitLinks()
   lazy val footer_links = new FooterLinks()
   lazy val head = new Head(optimizely_snippet, assetsConfig)
   lazy val header_nav = new HeaderNav()

--- a/src/main/play-26/uk/gov/hmrc/play/views/html/layouts/layouts.scala
+++ b/src/main/play-26/uk/gov/hmrc/play/views/html/layouts/layouts.scala
@@ -42,6 +42,9 @@ package object layouts {
   lazy val footer = new Footer(assetsConfig)
 
   @deprecated("Use DI")
+  lazy val eu_exit_links = new EuExitLinks()
+
+  @deprecated("Use DI")
   lazy val footer_links = new FooterLinks()
 
   @deprecated("Use DI")

--- a/src/main/resources/messages
+++ b/src/main/resources/messages
@@ -22,6 +22,11 @@ error.address.invalid.character=This line contains an invalid character. Valid c
 error.postcode.length.violation=Postcode is incorrect
 error.postcode.invalid.character=This line contains an invalid character. Valid characters are: A-Z a-z 0-9 space
 
+eu-exit.links.business-prepare.text=Prepare your business for the UK leaving the EU
+eu-exit.links.individual-prepare.text=Prepare for EU Exit if you live in the UK
+eu-exit.links.live-in-europe.text=Living in Europe after the UK leaves the EU
+eu-exit.links.live-in-uk.text=Continue to live in the UK after it leaves the EU
+
 footer.links.help_page.text=Help using GOV.UK
 footer.links.help_page.url=https://www.gov.uk/help
 footer.links.cookies.text=Cookies

--- a/src/main/resources/messages
+++ b/src/main/resources/messages
@@ -22,6 +22,7 @@ error.address.invalid.character=This line contains an invalid character. Valid c
 error.postcode.length.violation=Postcode is incorrect
 error.postcode.invalid.character=This line contains an invalid character. Valid characters are: A-Z a-z 0-9 space
 
+eu-exit.links.heading.text=Prepare for EU Exit
 eu-exit.links.business-prepare.text=Prepare your business for the UK leaving the EU
 eu-exit.links.individual-prepare.text=Prepare for EU Exit if you live in the UK
 eu-exit.links.live-in-europe.text=Living in Europe after the UK leaves the EU

--- a/src/main/resources/messages.cy
+++ b/src/main/resources/messages.cy
@@ -15,6 +15,11 @@ label.beta.yours=– bydd eich
 
 report.a.problem.link=Help gyda''r dudalen hon.
 
+eu-exit.links.business-prepare.text=
+eu-exit.links.individual-prepare.text=
+eu-exit.links.live-in-europe.text=
+eu-exit.links.live-in-uk.text=
+
 footer.links.cookies.text=Cwcis
 footer.links.privacy_policy.text=Polisi preifatrwydd
 footer.links.terms_and_conditions.text=Telerau ac Amodau

--- a/src/main/resources/messages.cy
+++ b/src/main/resources/messages.cy
@@ -15,10 +15,11 @@ label.beta.yours=– bydd eich
 
 report.a.problem.link=Help gyda''r dudalen hon.
 
-eu-exit.links.business-prepare.text=
-eu-exit.links.individual-prepare.text=
-eu-exit.links.live-in-europe.text=
-eu-exit.links.live-in-uk.text=
+eu-exit.links.heading.text=Paratoi ar gyfer Ymadael â’r UE (Saesneg yn unig)
+eu-exit.links.business-prepare.text=Paratoi eich busnes ar gyfer y DU yn gadael yr UE (Saesneg yn unig)
+eu-exit.links.individual-prepare.text=Paratoi ar gyfer Ymadael â’r UE os ydych yn byw yn y DU (Saesneg yn unig)
+eu-exit.links.live-in-europe.text=Byw yn Ewrop ar ôl i’r DU adael yr UE (Saesneg yn unig)
+eu-exit.links.live-in-uk.text=Parhau i fyw yn y DU ar ôl iddi adael yr UE (Saesneg yn unig)
 
 footer.links.cookies.text=Cwcis
 footer.links.privacy_policy.text=Polisi preifatrwydd

--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/EuExitLinks.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/EuExitLinks.scala.html
@@ -18,7 +18,7 @@
 
 @(implicit messages: Messages)
 
-<h2 class="heading-medium">Prepare for EU Exit</h2>
+<h2 class="heading-medium">@Messages("eu-exit.links.heading.text")</h2>
 <hr>
 <div class="grid-row">
   <ul class="push--bottom">

--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/EuExitLinks.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/EuExitLinks.scala.html
@@ -39,7 +39,7 @@
       <li><p><a href="https://www.gov.uk/uk-nationals-living-eu"
                 target="_blank"
                 data-sso="false"
-                data-journey-click="footer:footer:Click:Living in Europe after the UK leaves the EU">
+                data-journey-click="footer:Click:Living in Europe after the UK leaves the EU">
         @Messages("eu-exit.links.live-in-europe.text")</a></p></li>
 
       <li><p><a href="https://www.gov.uk/staying-uk-eu-citizen"

--- a/src/main/twirl/uk/gov/hmrc/play/views/layouts/EuExitLinks.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/layouts/EuExitLinks.scala.html
@@ -1,0 +1,53 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(implicit messages: Messages)
+
+<h2 class="heading-medium">Prepare for EU Exit</h2>
+<hr>
+<div class="grid-row">
+  <ul class="push--bottom">
+    <div class="column-one-half">
+      <li><p><a href="https://www.gov.uk/business-uk-leaving-eu"
+                target="_blank"
+                data-sso="false"
+                data-journey-click="footer:Click:Prepare your business for the UK leaving the EU">
+        @Messages("eu-exit.links.business-prepare.text")></a></p></li>
+
+      <li><p><a href="https://www.gov.uk/prepare-eu-exit"
+                target="_blank"
+                data-sso="false"
+                data-journey-click="footer:Prepare for EU Exit if you live in the UK">
+        @Messages("eu-exit.links.individual-prepare.text")></a></p></li>
+    </div>
+    <div class="column-one-half">
+      <li><p><a href="https://www.gov.uk/uk-nationals-living-eu"
+                target="_blank"
+                data-sso="false"
+                data-journey-click="footer:footer:Click:Living in Europe after the UK leaves the EU">
+        @Messages("eu-exit.links.live-in-europe.text")</a></p></li>
+
+      <li><p><a href="https://www.gov.uk/staying-uk-eu-citizen"
+                target="_blank"
+                data-sso="false"
+                data-journey-click="footer:Click:Continue to live in the UK after it leaves the EU">
+        @Messages("eu-exit.links.live-in-uk.text")</a></p></li>
+    </div>
+  </ul>
+</div>
+<hr>


### PR DESCRIPTION
## Problem
Some services will need to add links into the footer which take users to guidance published by the UK Government for individuals and businesses relating to the UK's exit from the European Union.

The guidance is only available in English, but the links need to be available on pages available in Welsh, therefore the text for the links is available in both English and Welsh.

## Implementation
Following patterns already established in play-ui, the EU Exit Links are an optional parameter provided to the Footer Links, which are passed into the call to GOVUK Template in services using the Twirl version of GOVUK Template.
 