### PR TITLE
PLATUI-BAU Fix Travis: OpenJDK8; not OracleJava8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ scala:
 - 2.11.7
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 
 script:


### PR DESCRIPTION
OracleJava8 no longer supported; fix check to look for OpenJDK8, which is what is now used on the Platform