### PR TITLE
APB-4550[AL] Add error prefix

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/Input.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/Input.scala.html
@@ -1,18 +1,18 @@
 @*
- * Copyright 2019 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+* Copyright 2019 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 
 @this()
 
@@ -30,67 +30,68 @@
 
 <label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if((elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) && !elements.args.contains('_hideBar)) {form-field--error}" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
 
-    @if(parentElements.isDefined) {
-        @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}
-    }
+@if(parentElements.isDefined) {
+    @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}
+}
 
-    @if(!labelAfter && elements.args.contains('_label)) {
-        @if(labelHighlight){<strong>}
-        <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
-            @elements.label
-        </span>
-        @if(elements.args.contains('_inputHint) ){
-            <span class="form-hint"
-                @if(elements.args.contains('_hintId)) {
-                    id="@elements.args.get('_hintId)"
+@if(!labelAfter && elements.args.contains('_label)) {
+    @if(labelHighlight){<strong>}
+    <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
+    @elements.label
+    </span>
+    @if(elements.args.contains('_inputHint) ){
+        <span class="form-hint"
+            @if(elements.args.contains('_hintId)) {
+                id="@elements.args.get('_hintId)"
                 }>
-                @elements.args.get('_inputHint)
-            </span>
-        }
-        @if(labelHighlight){</strong>}
-
+        @elements.args.get('_inputHint)
+        </span>
     }
+    @if(labelHighlight){</strong>}
 
-    @if(!elements.args.contains('_hideErrors)) {
-        @elements.errors.map { error =>
+}
+
+@if(!elements.args.contains('_hideErrors)) {
+    @elements.errors.map { error =>
         <span class="error-notification"
             @if(elements.args.contains('_error_id)) {
                 id="@elements.args.get('_error_id)"
             }
-            role="tooltip"
-            data-journey="search-page:error:@elements.field.name">
+        role="tooltip"
+        data-journey="search-page:error:@elements.field.name">
+            @if(elements.args.contains('_errorPrefix) ){<span class="visually-hidden">@elements.args.get('_errorPrefix) </span>}
             @Messages(error)
         </span>
-        }
     }
+}
 
-    <input
-        @if( elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
-        @if( elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
-        @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
-        @if( elements.args.get('_autoComplete) ){ autocomplete="@elements.args.get('_autoComplete)" }
-           name="@elements.field.name"
-           id="@elements.field.name"
-           value="@value"
-        @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
-        @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
-        @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
-        @if(elements.args.get('_min).isDefined) { min="@elements.args.get('_min)" }
-        @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
-        @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
-        @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
-        @if(elements.args.get('_required).isDefined) { required }
-           />
+<input
+    @if( elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
+    @if( elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
+    @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
+    @if( elements.args.get('_autoComplete) ){ autocomplete="@elements.args.get('_autoComplete)" }
+name="@elements.field.name"
+id="@elements.field.name"
+value="@value"
+    @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
+    @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
+    @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
+    @if(elements.args.get('_min).isDefined) { min="@elements.args.get('_min)" }
+    @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
+    @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
+    @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
+@if(elements.args.get('_required).isDefined) { required }
+    />
 
-    @if(labelAfter && elements.args.contains('_label)) {
-        @if(labelHighlight){<strong>}
-        <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
-            @elements.label
-        </span>
-        @if(elements.args.contains('_inputHint) ){
-            <span class="form-hint">@elements.args.get('_inputHint)</span>
-        }
-        @if(labelHighlight){</strong>}
+@if(labelAfter && elements.args.contains('_label)) {
+    @if(labelHighlight){<strong>}
+    <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
+    @elements.label
+    </span>
+    @if(elements.args.contains('_inputHint) ){
+        <span class="form-hint">@elements.args.get('_inputHint)</span>
     }
+    @if(labelHighlight){</strong>}
+}
 
-</label>
+    </label>

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/Input.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/Input.scala.html
@@ -1,18 +1,18 @@
 @*
-* Copyright 2019 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
 
 @this()
 
@@ -30,68 +30,68 @@
 
 <label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if((elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) && !elements.args.contains('_hideBar)) {form-field--error}" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
 
-@if(parentElements.isDefined) {
-    @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}
-}
-
-@if(!labelAfter && elements.args.contains('_label)) {
-    @if(labelHighlight){<strong>}
-    <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
-    @elements.label
-    </span>
-    @if(elements.args.contains('_inputHint) ){
-        <span class="form-hint"
-            @if(elements.args.contains('_hintId)) {
-                id="@elements.args.get('_hintId)"
-                }>
-        @elements.args.get('_inputHint)
-        </span>
+    @if(parentElements.isDefined) {
+        @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}
     }
-    @if(labelHighlight){</strong>}
 
-}
+    @if(!labelAfter && elements.args.contains('_label)) {
+        @if(labelHighlight){<strong>}
+        <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
+            @elements.label
+        </span>
+        @if(elements.args.contains('_inputHint) ){
+            <span class="form-hint"
+                @if(elements.args.contains('_hintId)) {
+                    id="@elements.args.get('_hintId)"
+                }>
+                @elements.args.get('_inputHint)
+            </span>
+        }
+        @if(labelHighlight){</strong>}
 
-@if(!elements.args.contains('_hideErrors)) {
-    @elements.errors.map { error =>
+    }
+
+    @if(!elements.args.contains('_hideErrors)) {
+        @elements.errors.map { error =>
         <span class="error-notification"
             @if(elements.args.contains('_error_id)) {
                 id="@elements.args.get('_error_id)"
             }
-        role="tooltip"
-        data-journey="search-page:error:@elements.field.name">
+            role="tooltip"
+            data-journey="search-page:error:@elements.field.name">
             @if(elements.args.contains('_errorPrefix) ){<span class="visually-hidden">@elements.args.get('_errorPrefix) </span>}
             @Messages(error)
         </span>
+        }
     }
-}
 
-<input
-    @if( elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
-    @if( elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
-    @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
-    @if( elements.args.get('_autoComplete) ){ autocomplete="@elements.args.get('_autoComplete)" }
-name="@elements.field.name"
-id="@elements.field.name"
-value="@value"
-    @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
-    @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
-    @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
-    @if(elements.args.get('_min).isDefined) { min="@elements.args.get('_min)" }
-    @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
-    @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
-    @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
-@if(elements.args.get('_required).isDefined) { required }
-    />
+    <input
+        @if( elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
+        @if( elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
+        @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
+        @if( elements.args.get('_autoComplete) ){ autocomplete="@elements.args.get('_autoComplete)" }
+           name="@elements.field.name"
+           id="@elements.field.name"
+           value="@value"
+        @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
+        @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
+        @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
+        @if(elements.args.get('_min).isDefined) { min="@elements.args.get('_min)" }
+        @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
+        @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
+        @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
+        @if(elements.args.get('_required).isDefined) { required }
+           />
 
-@if(labelAfter && elements.args.contains('_label)) {
-    @if(labelHighlight){<strong>}
-    <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
-    @elements.label
-    </span>
-    @if(elements.args.contains('_inputHint) ){
-        <span class="form-hint">@elements.args.get('_inputHint)</span>
+    @if(labelAfter && elements.args.contains('_label)) {
+        @if(labelHighlight){<strong>}
+        <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
+            @elements.label
+        </span>
+        @if(elements.args.contains('_inputHint) ){
+            <span class="form-hint">@elements.args.get('_inputHint)</span>
+        }
+        @if(labelHighlight){</strong>}
     }
-    @if(labelHighlight){</strong>}
-}
 
-    </label>
+</label>

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/InputRadioGroup.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/InputRadioGroup.scala.html
@@ -1,24 +1,24 @@
 @*
-* Copyright 2019 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
 
 @this()
 
 @(field: Field,
-        radioOptions: Seq[(String, String)],
-        args: (Symbol, Any)*
+  radioOptions: Seq[(String, String)],
+  args: (Symbol, Any)*
 )(implicit messages: Messages)
 
 @import views.html.helper._
@@ -30,11 +30,11 @@
 
 <div class="@groupDivClass">
     <fieldset class="@fieldsetClass"
-        @if(elements.args.get('_fieldsetAttributes).isDefined) {@elements.args.get('_fieldsetAttributes)}>
+    @if(elements.args.get('_fieldsetAttributes).isDefined) {@elements.args.get('_fieldsetAttributes)}>
     @if(elements.args.get('_legend).isDefined) {
         <legend @if(elements.args.get('_legendClass).isDefined) {class="@elements.args.get('_legendClass)"}
-            @if(elements.args.get('_legendID).isDefined) {id="@elements.args.get('_legendID)"}>
-        @elements.args.get('_legend)
+                @if(elements.args.get('_legendID).isDefined) {id="@elements.args.get('_legendID)"}>
+            @elements.args.get('_legend)
         </legend>
     }
     @elements.errors.map{error => <span class="error-notification">@if(elements.args.contains('_errorPrefix) ){<span class="visually-hidden">@elements.args.get('_errorPrefix) </span>}@Messages(error)</span>}
@@ -43,10 +43,10 @@
         @defining(s"${elements.field.name}-${value.toLowerCase.replace(" ","_")}")  { inputId =>
             <div class="multiple-choice">
                 <input
-                type="radio"
-                id="@inputId"
-                name="@elements.field.name"
-                value="@value"
+                    type="radio"
+                    id="@inputId"
+                    name="@elements.field.name"
+                    value="@value"
                     @elements.args.get('_inputClass).map{inputClass => class="@inputClass"}
                     @if(elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
                     @field.value.filter( _ == value).map{_ => checked="checked"}/>

--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/InputRadioGroup.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/InputRadioGroup.scala.html
@@ -1,24 +1,24 @@
 @*
- * Copyright 2019 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+* Copyright 2019 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 
 @this()
 
 @(field: Field,
-  radioOptions: Seq[(String, String)],
-  args: (Symbol, Any)*
+        radioOptions: Seq[(String, String)],
+        args: (Symbol, Any)*
 )(implicit messages: Messages)
 
 @import views.html.helper._
@@ -30,23 +30,23 @@
 
 <div class="@groupDivClass">
     <fieldset class="@fieldsetClass"
-    @if(elements.args.get('_fieldsetAttributes).isDefined) {@elements.args.get('_fieldsetAttributes)}>
+        @if(elements.args.get('_fieldsetAttributes).isDefined) {@elements.args.get('_fieldsetAttributes)}>
     @if(elements.args.get('_legend).isDefined) {
         <legend @if(elements.args.get('_legendClass).isDefined) {class="@elements.args.get('_legendClass)"}
-                @if(elements.args.get('_legendID).isDefined) {id="@elements.args.get('_legendID)"}>
-            @elements.args.get('_legend)
+            @if(elements.args.get('_legendID).isDefined) {id="@elements.args.get('_legendID)"}>
+        @elements.args.get('_legend)
         </legend>
     }
-    @elements.errors.map{error => <span class="error-notification">@Messages(error)</span>}
+    @elements.errors.map{error => <span class="error-notification">@if(elements.args.contains('_errorPrefix) ){<span class="visually-hidden">@elements.args.get('_errorPrefix) </span>}@Messages(error)</span>}
 
     @radioOptions.map { case (value, label) =>
         @defining(s"${elements.field.name}-${value.toLowerCase.replace(" ","_")}")  { inputId =>
             <div class="multiple-choice">
                 <input
-                    type="radio"
-                    id="@inputId"
-                    name="@elements.field.name"
-                    value="@value"
+                type="radio"
+                id="@inputId"
+                name="@elements.field.name"
+                value="@value"
                     @elements.args.get('_inputClass).map{inputClass => class="@inputClass"}
                     @if(elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
                     @field.value.filter( _ == value).map{_ => checked="checked"}/>


### PR DESCRIPTION
‘Error’ should be included as part of inline error handling, as per the GOV.UK Design System:

https://design-system.service.gov.uk/components/error-message/

An optional errorPrefix has been added which would include the text "Error: " that could be contained in a service's messages file.