### PR TITLE
Allowed for additional args in DatesFreeInlineLegend error messages

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/DateFieldsFreeInlineLegend.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/DateFieldsFreeInlineLegend.scala.html
@@ -42,7 +42,7 @@
                 @args.toMap.get('_errorPrefix).map { errorPrefix =>
                     <span class="visually-hidden">@errorPrefix </span>
                 }
-                @Messages(error.message)
+                @Messages(error.message, error.args: _*)
             </span>}
         </legend>
 


### PR DESCRIPTION
Tested locally with a play 2.6 snapshot version.