### PR TITLE
ECC-330 - add support for inputmode attribute

### DIFF
--- a/src/main/twirl/uk/gov/hmrc/play/views/helpers/Input.scala.html
+++ b/src/main/twirl/uk/gov/hmrc/play/views/helpers/Input.scala.html
@@ -79,6 +79,7 @@
         @if(elements.args.get('_min).isDefined) { min="@elements.args.get('_min)" }
         @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
         @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
+        @if(elements.args.get('_inputmode).isDefined) { inputmode="@elements.args.get('_inputmode)" }
         @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
         @if(elements.args.get('_required).isDefined) { required }
            />


### PR DESCRIPTION
We've had an accessibility issue raised by Adam Liptrot.   We would like to be able to set the inputmode attribute on an input field to "numeric".